### PR TITLE
Major Overhaul

### DIFF
--- a/Find-AdminSDHolder.ps1
+++ b/Find-AdminSDHolder.ps1
@@ -6,79 +6,122 @@ $outputFilePath = "{0}_AdminSDHolders.csv" -f $env:USERDOMAIN
 $domainDN = Get-ADDomain | Select-Object -Expand DistinguishedName
 
 # ACLs we want to target..any one of these needs to be considered high risk!
-$targetAdRightsToAudit = @("CreateChild", "DeleteChild", "WriteOwner", "WriteProperty", "WriteDacl")
-
-# Get unique entry as key for hashtable and append rights:
-$idMap = @{}
-Get-Acl -Path "AD:\CN=AdminSDHolder,CN=System,$domainDN" | Select-Object -ExpandProperty Access | ForEach-Object {
-    $adRights = $_.ActiveDirectoryRights -split ","
-
-    $idRef = $_.IdentityReference
-
-    if (-not($idMap.ContainsKey($idRef))) {
-        $idMap.Add($idRef, $adRights)
-    }
-    else {
-        $idMap[$idRef] += $adRights
-    }
-}
+$targetAdRightsToAudit = @("CreateChild", "DeleteChild", "WriteOwner", "WriteProperty", "WriteDacl", "GenericAll", "ExtendedRight")
 
 $groupMemberTable = @{}
 Get-ADGroup -Filter * -Properties Member | ForEach-Object {
     $groupMemberTable.Add($_.Name, $_.Member)
 }
 
+$ObjectTypeGUID = @{}
+
+$GetADObjectParameter=@{
+    SearchBase=(Get-ADRootDSE).SchemaNamingContext
+    LDAPFilter='(SchemaIDGUID=*)'
+    Properties=@("Name", "SchemaIDGUID")
+}
+
+Get-ADObject @GetADObjectParameter | ForEach-Object { $ObjectTypeGUID.Add(([GUID]$_.SchemaIDGUID),$_.Name) }
+
+
+$ADObjExtPar=@{
+    SearchBase="CN=Extended-Rights,$((Get-ADRootDSE).ConfigurationNamingContext)"
+    LDAPFilter='(ObjectClass=ControlAccessRight)'
+    Properties=@("Name", "RightsGUID")
+}
+
+Get-ADObject @ADObjExtPar |ForEach-Object { $ObjectTypeGUID.Add(([GUID]$_.RightsGUID),$_.Name) }
+
+
 # Class that will be used to represent the security principal and corresponding AD rights::
 class IdentityAcl {
     [string]$SecurityPrincipal
-    [string[]]$ActiveDirectoryRights
     [bool]$IsGroup
-    [string[]]$GroupMembers
+    [string]$GroupMembers
+    [string]$ActiveDirectoryRights
+    [string]$AttributeName
+    [string]$InheritedObjectType
+    [string]$InheritanceType
 
-    IdentityAcl($prinName, $adRights, $isAdGroup, $memberDNs) {
+    IdentityAcl($prinName, $isAdGroup, $memberDNs, $adRights,$attributeName,$inheritedObjectType,$inheritanceType) {
         $this.SecurityPrincipal = $prinName
-        $this.ActiveDirectoryRights = $adRights
         $this.IsGroup = $isAdGroup
         $this.GroupMembers = $memberDNs
+        $this.ActiveDirectoryRights = $adRights
+        $this.AttributeName = $attributeName
+        $this.InheritedObjectType = $inheritedObjectType
+        $this.InheritanceType = $inheritanceType
     }
 }
 
-# Iterate through the hashtable populated prior, instantiate an IdentityAcl object
-# with the identity as the SecurityPrincipal property and remove duplicate values for AD rights and
-# assign to the ActiveDirectoryRights property:
-$identityAcls = $idMap.GetEnumerator() | ForEach-Object {
-    $idFullName = $_.Name.Value
+$adRightsLabel = @{Label="ADRights";Expression={$PSItem.ActiveDirectoryRights -Split ', '}}
+
+$aclData = Get-Acl -Path "AD:\CN=AdminSDHolder,CN=System,$domainDN" | Select-Object -ExpandProperty Access
+
+$auditResults = New-Object -TypeName System.Collections.Generic.List[IdentityAcl]
+
+$aclData  | ForEach-Object {
+
+
+    [string]$idFullName = $_.IdentityReference
     $idName = $idFullName.Replace(($env:USERDOMAIN + "\"), "")
+    $idRefIsGroup = $groupMemberTable.ContainsKey($idName)
 
-    $adRights = ($_.Value | Select-Object -Unique).Trim()
-
-    if ($groupMemberTable.ContainsKey($idName)) {
-        $groupMemberDNs = $groupMemberTable[$idName]
-
-        $groupMembers = @()
-        $groupMemberDNs | ForEach-Object {
-            $groupMembers += ($_.Split(",")[0].Replace("CN=", ""))
-        }
-
-        [IdentityAcl]::new($idFullName, $adRights, $true, $groupMembers)
-    }
-    else {
-        [IdentityAcl]::new($idFullName, $adRights, $false, $null)
-    }
-}
-
-# Using Compare-Object and Where-Object, determine if any of the AD rights on the incoming objects exist in the $targetAdRightsToAudit array:
-$auditResults = $identityAcls | ForEach-Object {
-    [int]$aclCount = Compare-Object -ReferenceObject $targetAdRightsToAudit -DifferenceObject $_.ActiveDirectoryRights -IncludeEqual |
+    $adRights = $_ | Select-Object -Property $adRightsLabel | Select-Object -ExpandProperty ADRights | Select-Object -Unique
+    
+    # Using Compare-Object and Where-Object, determine if any of the AD rights on the incoming objects exist in the $targetAdRightsToAudit array:
+    [int]$aclCount = Compare-Object -ReferenceObject $targetAdRightsToAudit -DifferenceObject $adRights -IncludeEqual |
         Where-Object SideIndicator -eq "==" | Measure-Object | Select-Object -ExpandProperty Count
 
     if ($aclCount -ge 1) {
-        $ActiveDirectoryRights = @{Name = "ActiveDirectoryRights"; Expression = { $_.ActiveDirectoryRights -join ", " } }
-        $GroupMembers = @{Name = "GroupMembers"; Expression = { $_.GroupMembers -join ", " } }
-        $_ | Select-Object SecurityPrincipal, $ActiveDirectoryRights, IsGroup, $GroupMembers
+
+        If ($ObjectTypeGUID.ContainsKey($_.ObjectType))
+        {
+            $attributeName = $ObjectTypeGUID.Item($_.ObjectType)
+        }
+        Else
+        {
+            If ($_.ObjectType -eq '00000000-0000-0000-0000-000000000000')
+            {
+                $attributeName = 'All Properties'
+            }
+            Else
+            {
+                $attributeName = $_.ObjectType
+            }
+        }
+
+        If ($ObjectTypeGUID.ContainsKey($_.InheritedObjectType))
+        {
+            $inheritedObjectType = $ObjectTypeGUID.Item($_.InheritedObjectType)
+        }
+        Else
+        {
+            If ($_.InheritedObjectType -eq '00000000-0000-0000-0000-000000000000')
+            {
+                $inheritedObjectType = 'This Object'
+            }
+            Else
+            {
+                $inheritedObjectType = $_.InheritedObjectType
+            }
+        }        
+
+        if ($idRefIsGroup) {
+            $groupMemberDNs = $groupMemberTable[$idName]
+
+            $groupMembers = @()
+            $groupMemberDNs | ForEach-Object {
+                $groupMembers += ($_.Split(",")[0].Replace("CN=", ""))
+            }
+            $auditResults.add([IdentityAcl]::new($idFullName, $true, ($groupMembers -join ", "), $_.ActiveDirectoryRights,$attributeName,$inheritedObjectType,$_.InheritanceType))
+        }
+        else {
+            $auditResults.add([IdentityAcl]::new($idFullName, $false, $null, $_.ActiveDirectoryRights,$attributeName,$inheritedObjectType,$_.InheritanceType))
+        }
+
     }
 }
 
 $auditResults | Export-Csv -Path $outputFilePath -NoTypeInformation
 $auditResults | Out-GridView -Title ("AdminSDHolders for $env:USERDNSDOMAIN")
-#---------------------------------------------------- END Find-AdminSDHolder.ps1 --------------------------------------------------------------------


### PR DESCRIPTION
I removed the second loop and added the isGroup lookup and is a permission to audit to the first loop through the permission set. Also added some lookups of GUIDS that represent different schema objects so it's more clear what access is being granted. This change might take away from the original purpose of just identifying the user's and groups with access though. With some of this additional info we could refine the filter for what permissions are included. With the original code there were a lot of false positives.